### PR TITLE
Pequenas correções de layout

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -10,6 +10,7 @@ const InputWrapper = styled.div`
     background: transparent;
     border: 0;
     border-bottom: 1px solid white;
+    box-shadow: none;
     color: white;
     font-size: 1.6rem;
     margin: 8px 0;

--- a/components/logo.js
+++ b/components/logo.js
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
 
 const Logo = styled.svg`
-  max-width: 200px;
-  min-width: 128px;
-  height: auto;
+  height: 128px;
   padding: 16px;
+  width: auto;
 `
 
 export default () => (


### PR DESCRIPTION
- Adição do `box-shadow: none` nos elementos `input` e `textarea` para correção de bug de layout no Firefox.
- No firefox o tamanho da logo ficava diferente do esperado.

![](https://media.giphy.com/media/TcG7Tw3uq6tJS/giphy.gif)